### PR TITLE
Separated GET users by hotel id from GET user by id

### DIFF
--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -16,22 +16,26 @@ const createToken = require('../utils/createToken');
  */
 
 routes.get('/', async (req, res, next) => {
-  if (req.query.hotel_id) {
-    const hotelId = req.query.hotel_id;
-    const hotel = await models.Hotel.findById(hotelId);
-    if (hotel) {
-      // if hotel id exists, find all users with that hotel ID and return them
-      const hotelUsers = await models.User.where({hotel_id: hotelId});
-      // filter only hotel staff
-      const hotelStaff = hotelUsers.filter(
-        user => user.user_type !== USER_TYPES.GUEST
-      );
-      res.status(200).json(hotelStaff);
-    }
-  }
   try {
-    const users = await models.User.find();
-    res.status(200).json(users);
+    if (req.query.hotel_id) {
+      // if there is hotel_id in query string, find all hotel staff
+      const hotelId = req.query.hotel_id;
+      const hotel = await models.Hotel.findById(hotelId);
+      if (hotel) {
+        // if hotel id exists, find all users with that hotel ID and return them
+        const hotelUsers = await models.User.where({ hotel_id: hotelId });
+        // filter only hotel staff
+        const hotelStaff = hotelUsers.filter(
+          user => user.user_type !== USER_TYPES.GUEST
+        );
+        res.status(200).json(hotelStaff);
+      } else {
+        res.status(404).json(errorMessages.noHotel);
+      }
+    } else {
+      const users = await models.User.find();
+      res.status(200).json(users);
+    }
   } catch (error) {
     next(error);
   }

--- a/routes/userRoutes.js
+++ b/routes/userRoutes.js
@@ -16,6 +16,19 @@ const createToken = require('../utils/createToken');
  */
 
 routes.get('/', async (req, res, next) => {
+  if (req.query.hotel_id) {
+    const hotelId = req.query.hotel_id;
+    const hotel = await models.Hotel.findById(hotelId);
+    if (hotel) {
+      // if hotel id exists, find all users with that hotel ID and return them
+      const hotelUsers = await models.User.where({hotel_id: hotelId});
+      // filter only hotel staff
+      const hotelStaff = hotelUsers.filter(
+        user => user.user_type !== USER_TYPES.GUEST
+      );
+      res.status(200).json(hotelStaff);
+    }
+  }
   try {
     const users = await models.User.find();
     res.status(200).json(users);
@@ -31,21 +44,8 @@ routes.get('/:_id', validateObjectId, async (req, res, next) => {
       // if the user id exists, return the user
       res.status(200).json(user);
     } else {
-      // if the user id does not exist
-      // check if a hotel id exist
-      const hotel = await models.Hotel.findById(req.params._id);
-      if (hotel) {
-        // if hotel id exists, find all users with that hotel ID and return them
-        const hotelUsers = await models.User.where({ hotel_id: hotel._id });
-        // filter only hotel staff
-        const hotelStaff = hotelUsers.filter(
-          user => user.user_type !== USER_TYPES.GUEST
-        );
-        res.status(200).json(hotelStaff);
-      } else {
-        // if user or hotel id does not exist, send error msg
-        res.status(404).json(errorMessages.getUserById);
-      }
+      // if user or hotel id does not exist, send error msg
+      res.status(404).json(errorMessages.getUserById);
     }
   } catch (error) {
     next(error);

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -88,13 +88,13 @@ describe('/api/auth', () => {
 
   describe('POST /login', () => {
     it('should return 200 on success', async () => {
-      const newUser = {
-        name: 'Joe',
+      const newUser1 = {
+        email: 'frank@hotmail.com',
         password: '1234',
       };
       return request(server)
         .post('/api/auth/login')
-        .send(newUser)
+        .send(newUser1)
         .expect(200);
     });
 

--- a/tests/integration/auth.test.js
+++ b/tests/integration/auth.test.js
@@ -21,7 +21,7 @@ describe('/api/auth', () => {
     await db.deleteMany({});
   });
 
-  it('is in the right environment', async () => {
+  it('is in the right environment', () => {
     expect(process.env.NODE_ENV).toBe('test');
   });
 
@@ -69,7 +69,7 @@ describe('/api/auth', () => {
         .expect(422);
     });
 
-    it('should return return the user object without password', async () => {
+    it('should return return the user object without password', async done => {
       const newUser4 = {
         hotel_id: '5cc74ab1f16ec37bc8cc4cdb',
         name: 'Frank',
@@ -83,6 +83,7 @@ describe('/api/auth', () => {
         .send(newUser4);
 
       expect(createdUser.text).not.toHaveProperty('password');
+      done();
     });
   });
 
@@ -109,7 +110,7 @@ describe('/api/auth', () => {
         .expect(401);
     });
 
-    it('should return return the user object without password', async () => {
+    it('should return return the user object without password', async done => {
       const newUser = {
         name: 'Joe',
         password: '1234',
@@ -119,6 +120,7 @@ describe('/api/auth', () => {
         .send(newUser);
 
       expect(createdUser.text).not.toHaveProperty('password');
+      done();
     });
   });
 });

--- a/tests/integration/users.test.js
+++ b/tests/integration/users.test.js
@@ -21,34 +21,38 @@ afterAll(async () => {
 });
 
 describe('/api/users', () => {
-  it('should set the testing environment', async () => {
+  it('should set the testing environment', () => {
     expect(process.env.NODE_ENV).toBe('test');
   });
 
   describe('GET /', () => {
-    it('should return 200 OK if request is successful', async () => {
+    it('should return 200 OK if request is successful', async done => {
       const res = await request(server).get('/api/users');
       expect(res.status).toBe(200);
+      done();
     });
 
-    it('should return the correct number of users stored in the database', async () => {
+    it('should return the correct number of users stored in the database', async done => {
       const response = await request(server).get('/api/users');
       expect(response.body.length).toBe(0);
+      done();
     });
 
-    it('should return the correct response body', async () => {
+    it('should return the correct response body', async done => {
       const response = await request(server).get('/api/users');
       expect(response.body).toEqual([]);
+      done();
     });
 
-    it('should always return an array, even if there are no users stored in the database', async () => {
+    it('should always return an array, even if there are no users stored in the database', async done => {
       const response = await request(server).get('/api/users');
       expect(Array.isArray(response.body)).toBeTruthy();
+      done();
     });
   });
 
   describe('GET /:id', () => {
-    it('should return 200 OK if request is successful', async () => {
+    it('should return 200 OK if request is successful', async done => {
       const newUser = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Ela',
@@ -64,16 +68,18 @@ describe('/api/users', () => {
       const id = createdUser.body.user._id;
       const response = await request(server).get(`/api/users/${id}`);
       expect(response.status).toEqual(200);
+      done();
     });
 
-    it('should return 404 Not Found if the id is not found in the database', async () => {
+    it('should return 404 Not Found if the id is not found in the database', async done => {
       const response = await request(server).get(
         '/api/users/5ccadf26f824a6313c8a4747'
       );
       expect(response.status).toEqual(404);
+      done();
     });
 
-    it('should return the correct response body if the request is successful', async () => {
+    it('should return the correct response body if the request is successful', async done => {
       const newUser2 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Anton',
@@ -94,11 +100,12 @@ describe('/api/users', () => {
         'Streamlined contextually-based interface'
       );
       expect(response.body.user_type).toEqual('receptionist');
+      done();
     });
   });
 
   describe('POST /', () => {
-    it('should return 201 Created if the request is successful', async () => {
+    it('should return 201 Created if the request is successful', async done => {
       const newUser3 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Andrea',
@@ -111,9 +118,10 @@ describe('/api/users', () => {
         .post('/api/users')
         .send(newUser3)
         .expect(201);
+      done();
     });
 
-    it('should return the newly created user if the request is successful', async () => {
+    it('should return the newly created user if the request is successful', async done => {
       const newUser7 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Martina',
@@ -126,11 +134,12 @@ describe('/api/users', () => {
         .post('/api/users')
         .send(newUser7);
       expect(createdUser.body.user.name).toEqual('Martina');
+      done();
     });
   });
 
   describe('PUT /:id', () => {
-    it('should return 200 OK if the request is successful', async () => {
+    it('should return 200 OK if the request is successful', async done => {
       const newUser8 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Samuel',
@@ -155,9 +164,10 @@ describe('/api/users', () => {
         .put(`/api/users/${id}`)
         .send(updatedUser);
       expect(response.status).toBe(200);
+      done();
     });
 
-    it('should remove the password from the response body', async () => {
+    it('should remove the password from the response body', async done => {
       const newUser15 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Sabrina',
@@ -184,9 +194,10 @@ describe('/api/users', () => {
         .send(updatedUser);
 
       expect(response.body).not.toHaveProperty('password');
+      done();
     });
 
-    it('should return 404 Not Found if the user cannot be found in the database', async () => {
+    it('should return 404 Not Found if the user cannot be found in the database', async done => {
       const newUser9 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Winston',
@@ -210,9 +221,10 @@ describe('/api/users', () => {
         .put('/api/users/5cc742f4f8bb9f81214e75fd')
         .send(updatedUser);
       expect(response.status).toBe(404);
+      done();
     });
 
-    it('should return the updated user if the request is successful', async () => {
+    it('should return the updated user if the request is successful', async done => {
       const newUser10 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Lili',
@@ -238,11 +250,12 @@ describe('/api/users', () => {
         .send(updatedUser);
       expect(response.body.name).toEqual('Leyla');
       expect(response.body.email).toEqual('leyla.roman@gmail.com');
+      done();
     });
   });
 
   describe('DELETE /:id', () => {
-    it('should return 200 OK if the request is successful', async () => {
+    it('should return 200 OK if the request is successful', async done => {
       const newUser11 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Anya',
@@ -257,9 +270,10 @@ describe('/api/users', () => {
       const id = createdUser.body.user._id;
       const response = await request(server).delete(`/api/users/${id}`);
       expect(response.status).toBe(200);
+      done();
     });
 
-    it('should return 404 Not Found if the user cannot be found in the database', async () => {
+    it('should return 404 Not Found if the user cannot be found in the database', async done => {
       const newUser12 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Anya',
@@ -275,9 +289,10 @@ describe('/api/users', () => {
       const response1 = await request(server).delete(`/api/users/${id}`);
       const response2 = await request(server).delete(`/api/users/${id}`);
       expect(response2.status).toEqual(404);
+      done();
     });
 
-    it('should remove the password from the response body', async () => {
+    it('should remove the password from the response body', async done => {
       const newUser13 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Antonia',
@@ -291,9 +306,10 @@ describe('/api/users', () => {
         .send(newUser13);
 
       expect(createdUser.body.user).not.toHaveProperty('password');
+      done();
     });
 
-    it('should return the correct message if the request is successful', async () => {
+    it('should return the correct message if the request is successful', async done => {
       const newUser14 = {
         hotel_id: '5cc742f4f8bb9f81214e75fe',
         name: 'Anya',
@@ -310,6 +326,7 @@ describe('/api/users', () => {
       expect(response.body.message).toEqual(
         'The user has been removed from the database'
       );
+      done();
     });
   });
 });


### PR DESCRIPTION
# Description


The existing version was making it difficult to use the endpoint so I changed the GET all users endpoint to take in query strings for hotel_id and cleaned up GET /:id to only return a user by id.

Fixes #51 



## Type of change


bug fix

## Change status


- [ ] Complete, tested, ready to review and merge

- [x] Complete, but not tested (may need new tests)

- [ ] Incomplete/work-in-progress, PR is for discussion/feedback



# How Has This Been Tested?



Tested with Postman



# Checklist:



- [x] My code follows the style guidelines of this project

- [x] I have performed a self-review of my own code

- [ ] I have commented my code, particularly in hard-to-understand areas

- [ ] I have made corresponding changes to the documentation, if relevant

- [x] I have run the app using my feature and ensured that no functionality is broken

- [x] My changes generate no new warnings

- [x] There are no merge conflicts
