### PR TITLE
Save text to translate in array

### DIFF
--- a/api/translate.js
+++ b/api/translate.js
@@ -5,9 +5,9 @@ const GOOGLE_TRANSLATE_DOMAIN =
 
 async function translateToEnglish(textToTranslate) {
   try {
-    Array.isArray(textToTranslate) ? textToTranslate : [textToTranslate];
+    const textArray = Array.isArray(textToTranslate) ? textToTranslate : [textToTranslate];
     // take an array of strings to translate
-    const encodedArr = textToTranslate.map(text => {
+    const encodedArr = textArray.map(text => {
       // encode text characters with UTF-8 encoding of the character
       let encodedText = encodeURIComponent(text);
       return `&q=${encodedText}`;


### PR DESCRIPTION
# Description


Quick fix to save `textToTranslate` to an array variable. Prevent issues with strings passed int.
